### PR TITLE
(fix) Compilation for latest r2d2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ use iron::prelude::*;
 use iron::{typemap, BeforeMiddleware};
 
 use std::sync::Arc;
-use std::default::Default;
 use postgres::{SslMode};
 use r2d2_postgres::PostgresConnectionManager;
 
@@ -32,10 +31,11 @@ impl PostgresMiddleware {
   ///
   /// **Panics** if there are any errors connecting to the postgresql database.
   pub fn new(pg_connection_str: &str) -> PostgresMiddleware {
-    let config = Default::default();
+    let config = r2d2::Config::builder()
+        .error_handler(Box::new(r2d2::LoggingErrorHandler))
+        .build();
     let manager = PostgresConnectionManager::new(pg_connection_str, SslMode::None).unwrap();
-    let error_handler = r2d2::LoggingErrorHandler;
-    let pool = Arc::new(r2d2::Pool::new(config, manager, Box::new(error_handler)).unwrap());
+    let pool = Arc::new(r2d2::Pool::new(config, manager).unwrap());
     PostgresMiddleware {
       pool: pool,
     }


### PR DESCRIPTION
`r2d2` recently moved `error_handler` to `r2d2::Config` with sfackler/r2d2@d3fd93aeb7f04c9a490c0004018b8b53499e7ba4.
