### PR TITLE
Enable syntax highlighting in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,41 @@
 # iron-postgres-middleware
 
-An attempt to create postgres middleware for [Iron](https://github.com/iron/iron/) web framework
+An attempt to create postgres middleware for the [Iron](https://github.com/iron/iron/) web framework
 
 ## Usage
 
 ### Cargo.toml
 
-    [dependencies.iron-postgres-middleware]
-    git = "https://github.com/martinsp/iron-postgres-middleware.git"
+```toml
+[dependencies.iron-postgres-middleware]
+git = "https://github.com/martinsp/iron-postgres-middleware.git"
+```
 
 ### Import
 
-    extern crate iron_postgres_middleware as pg_middleware;
-    use pg_middleware::{PostgresMiddleware, PostgresReqExt};
+```rust
+extern crate iron_postgres_middleware as pg_middleware;
+use pg_middleware::{PostgresMiddleware, PostgresReqExt};
+```
 
-### Using middleware
+### Middleware
 
-    fn main() {
-      let mut router = Router::new();
-      router.get("/", handler);
+```rust
+fn main() {
+  let mut router = Router::new();
+  router.get("/", handler);
 
-      let mut c = Chain::new(router);
+  let mut c = Chain::new(router);
 
-      let pg_middleware = PostgresMiddleware::new("postgres://user@localhost/db_name");
-      c.link_before(pg_middleware);
+  let pg_middleware = PostgresMiddleware::new("postgres://user@localhost/db_name");
+  c.link_before(pg_middleware);
 
-      Iron::new(c).http("localhost:3000").unwrap();
-    }
+  Iron::new(c).http("localhost:3000").unwrap();
+}
 
-    fn handler(req: &mut Request) -> IronResult<Response> {
-      let con = req.db_conn();
-      con.execute("INSERT INTO foo (bar) VALUES ($1)", &[&1i32]).unwrap();
-      Ok(Response::new().set(status::Ok).set("Success"))
-    }
+fn handler(req: &mut Request) -> IronResult<Response> {
+  let con = req.db_conn();
+  con.execute("INSERT INTO foo (bar) VALUES ($1)", &[&1i32]).unwrap();
+  Ok(Response::new().set(status::Ok).set("Success"))
+}
+```


### PR DESCRIPTION
So far your middleware has served me well, just thought the README could do with some syntax highlighting.

What are your plans more broadly for this? Would you like to publish on crates.io? If so, I think you could shorten the name to just `iron_postgres`.
